### PR TITLE
Introduce foreigner network

### DIFF
--- a/easytier-core/src/common/global_ctx.rs
+++ b/easytier-core/src/common/global_ctx.rs
@@ -2,6 +2,7 @@ use std::{io::Write, sync::Arc};
 
 use crate::rpc::PeerConnInfo;
 use crossbeam::atomic::AtomicCell;
+use serde::{Deserialize, Serialize};
 
 use super::{
     config_fs::ConfigFs,
@@ -21,11 +22,31 @@ pub enum GlobalCtxEvent {
 type EventBus = tokio::sync::broadcast::Sender<GlobalCtxEvent>;
 type EventBusSubscriber = tokio::sync::broadcast::Receiver<GlobalCtxEvent>;
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct NetworkIdentity {
+    pub network_name: String,
+    pub network_secret: String,
+}
+
+impl NetworkIdentity {
+    pub fn new(network_name: String, network_secret: String) -> Self {
+        NetworkIdentity {
+            network_name,
+            network_secret,
+        }
+    }
+
+    pub fn default() -> Self {
+        Self::new("default".to_string(), "".to_string())
+    }
+}
+
 pub struct GlobalCtx {
     pub inst_name: String,
     pub id: uuid::Uuid,
     pub config_fs: ConfigFs,
     pub net_ns: NetNS,
+    pub network: NetworkIdentity,
 
     event_bus: EventBus,
 
@@ -54,11 +75,17 @@ impl std::fmt::Debug for GlobalCtx {
 pub type ArcGlobalCtx = std::sync::Arc<GlobalCtx>;
 
 impl GlobalCtx {
-    pub fn new(inst_name: &str, config_fs: ConfigFs, net_ns: NetNS) -> Self {
+    pub fn new(
+        inst_name: &str,
+        config_fs: ConfigFs,
+        net_ns: NetNS,
+        network: Option<NetworkIdentity>,
+    ) -> Self {
         let id = config_fs
             .get_or_add_file("inst_id", || uuid::Uuid::new_v4().to_string())
             .unwrap();
         let id = uuid::Uuid::parse_str(&id).unwrap();
+        let network = network.unwrap_or(NetworkIdentity::default());
 
         let (event_bus, _) = tokio::sync::broadcast::channel(100);
 
@@ -67,6 +94,8 @@ impl GlobalCtx {
             id,
             config_fs,
             net_ns: net_ns.clone(),
+            network,
+
             event_bus,
             cached_ipv4: AtomicCell::new(None),
             cached_proxy_cidrs: AtomicCell::new(None),
@@ -203,7 +232,7 @@ pub mod tests {
     async fn test_global_ctx() {
         let config_fs = ConfigFs::new("/tmp/easytier");
         let net_ns = NetNS::new(None);
-        let global_ctx = GlobalCtx::new("test", config_fs, net_ns);
+        let global_ctx = GlobalCtx::new("test", config_fs, net_ns, None);
 
         let mut subscriber = global_ctx.subscribe();
         global_ctx.issue_event(GlobalCtxEvent::PeerAdded);
@@ -234,6 +263,7 @@ pub mod tests {
             format!("test_{}", node_id).as_str(),
             config_fs,
             net_ns,
+            None,
         ))
     }
 }

--- a/easytier-core/src/connector/manual.rs
+++ b/easytier-core/src/connector/manual.rs
@@ -220,8 +220,8 @@ impl ManualConnectorManager {
                 log::warn!("peer conn removed: {:?}", conn_info);
             }
 
-            GlobalCtxEvent::PeerAdded => todo!(),
-            GlobalCtxEvent::PeerRemoved => todo!(),
+            GlobalCtxEvent::PeerAdded(..) => todo!(),
+            GlobalCtxEvent::PeerRemoved(..) => todo!(),
         }
     }
 

--- a/easytier-core/src/connector/udp_hole_punch.rs
+++ b/easytier-core/src/connector/udp_hole_punch.rs
@@ -499,12 +499,18 @@ pub mod tests {
         }
     }
 
+    pub fn replace_stun_info_collector(peer_mgr: Arc<PeerManager>, udp_nat_type: NatType) {
+        let collector = Box::new(MockStunInfoCollector { udp_nat_type });
+        peer_mgr
+            .get_global_ctx()
+            .replace_stun_info_collector(collector);
+    }
+
     pub async fn create_mock_peer_manager_with_mock_stun(
         udp_nat_type: NatType,
     ) -> Arc<PeerManager> {
         let p_a = create_mock_peer_manager().await;
-        let collector = Box::new(MockStunInfoCollector { udp_nat_type });
-        p_a.get_global_ctx().replace_stun_info_collector(collector);
+        replace_stun_info_collector(p_a.clone(), udp_nat_type);
         p_a
     }
 

--- a/easytier-core/src/instance/instance.rs
+++ b/easytier-core/src/instance/instance.rs
@@ -116,7 +116,7 @@ impl Instance {
 
         let (peer_packet_sender, peer_packet_receiver) = tokio::sync::mpsc::channel(100);
 
-        let global_ctx = Arc::new(GlobalCtx::new(inst_name, config, net_ns.clone()));
+        let global_ctx = Arc::new(GlobalCtx::new(inst_name, config, net_ns.clone(), None));
 
         let id = global_ctx.get_id();
 

--- a/easytier-core/src/peers/foreign_network_client.rs
+++ b/easytier-core/src/peers/foreign_network_client.rs
@@ -1,0 +1,184 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use dashmap::DashMap;
+use tokio::{
+    sync::{mpsc, Mutex},
+    task::JoinSet,
+};
+use tokio_util::bytes::Bytes;
+
+use crate::common::{
+    error::Error,
+    global_ctx::{ArcGlobalCtx, NetworkIdentity},
+};
+
+use super::{
+    foreign_network_manager::{ForeignNetworkServiceClient, FOREIGN_NETWORK_SERVICE_ID},
+    peer_conn::PeerConn,
+    peer_map::PeerMap,
+    peer_rpc::PeerRpcManager,
+    PeerId,
+};
+
+pub struct ForeignNetworkClient {
+    global_ctx: ArcGlobalCtx,
+    peer_rpc: Arc<PeerRpcManager>,
+
+    peer_map: Arc<PeerMap>,
+
+    next_hop: Arc<DashMap<PeerId, PeerId>>,
+    tasks: Mutex<JoinSet<()>>,
+}
+
+impl ForeignNetworkClient {
+    pub fn new(
+        global_ctx: ArcGlobalCtx,
+        packet_sender_to_mgr: mpsc::Sender<Bytes>,
+        peer_rpc: Arc<PeerRpcManager>,
+    ) -> Self {
+        let peer_map = Arc::new(PeerMap::new(packet_sender_to_mgr, global_ctx.clone()));
+        let next_hop = Arc::new(DashMap::new());
+
+        Self {
+            global_ctx,
+            peer_rpc,
+
+            peer_map,
+
+            next_hop,
+            tasks: Mutex::new(JoinSet::new()),
+        }
+    }
+
+    pub async fn add_new_peer_conn(&self, peer_conn: PeerConn) {
+        tracing::warn!(peer_conn = ?peer_conn.get_conn_info(), network = ?peer_conn.get_network_identity(), "add new peer conn in foreign network client");
+        self.peer_map.add_new_peer_conn(peer_conn).await
+    }
+
+    async fn collect_next_hop_in_foreign_network_task(
+        network_identity: NetworkIdentity,
+        peer_map: Arc<PeerMap>,
+        peer_rpc: Arc<PeerRpcManager>,
+        next_hop: Arc<DashMap<PeerId, PeerId>>,
+    ) {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+            peer_map.clean_peer_without_conn().await;
+
+            let new_next_hop = Self::collect_next_hop_in_foreign_network(
+                network_identity.clone(),
+                peer_map.clone(),
+                peer_rpc.clone(),
+            )
+            .await;
+
+            next_hop.clear();
+            for (k, v) in new_next_hop.into_iter() {
+                next_hop.insert(k, v);
+            }
+        }
+    }
+
+    async fn collect_next_hop_in_foreign_network(
+        network_identity: NetworkIdentity,
+        peer_map: Arc<PeerMap>,
+        peer_rpc: Arc<PeerRpcManager>,
+    ) -> DashMap<PeerId, PeerId> {
+        let peers = peer_map.list_peers().await;
+        let mut tasks = JoinSet::new();
+        if !peers.is_empty() {
+            tracing::warn!(?peers, "collect next hop in foreign network");
+        }
+        for peer in peers {
+            let peer_rpc = peer_rpc.clone();
+            let network_identity = network_identity.clone();
+            tasks.spawn(async move {
+                let Ok(Some(peers_in_foreign)) = peer_rpc
+                    .do_client_rpc_scoped(FOREIGN_NETWORK_SERVICE_ID, peer, |c| async {
+                        let c =
+                            ForeignNetworkServiceClient::new(tarpc::client::Config::default(), c)
+                                .spawn();
+                        let mut rpc_ctx = tarpc::context::current();
+                        rpc_ctx.deadline = SystemTime::now() + Duration::from_secs(2);
+                        let ret = c.list_network_peers(rpc_ctx, network_identity).await;
+                        ret
+                    })
+                    .await
+                else {
+                    return (peer, vec![]);
+                };
+
+                (peer, peers_in_foreign)
+            });
+        }
+
+        let new_next_hop = DashMap::new();
+        while let Some(join_ret) = tasks.join_next().await {
+            let Ok((gateway, peer_ids)) = join_ret else {
+                tracing::error!(?join_ret, "collect next hop in foreign network failed");
+                continue;
+            };
+            for ret in peer_ids {
+                new_next_hop.insert(ret, gateway);
+            }
+        }
+
+        new_next_hop
+    }
+
+    pub fn has_next_hop(&self, peer_id: &PeerId) -> bool {
+        self.get_next_hop(peer_id).is_some()
+    }
+
+    pub fn get_next_hop(&self, peer_id: &PeerId) -> Option<PeerId> {
+        if self.peer_map.has_peer(peer_id) {
+            return Some(peer_id.clone());
+        }
+        self.next_hop.get(peer_id).map(|v| v.clone())
+    }
+
+    pub async fn send_msg(&self, msg: Bytes, peer_id: &PeerId) -> Result<(), Error> {
+        if let Some(next_hop) = self.get_next_hop(peer_id) {
+            return self.peer_map.send_msg_directly(msg, &next_hop).await;
+        }
+        Err(Error::RouteError("no next hop".to_string()))
+    }
+
+    pub fn list_foreign_peers(&self) -> Vec<PeerId> {
+        let mut peers = vec![];
+        for item in self.next_hop.iter() {
+            if item.key() != &self.global_ctx.get_id() {
+                peers.push(item.key().clone());
+            }
+        }
+        peers
+    }
+
+    pub async fn run(&self) {
+        self.tasks
+            .lock()
+            .await
+            .spawn(Self::collect_next_hop_in_foreign_network_task(
+                self.global_ctx.get_network_identity(),
+                self.peer_map.clone(),
+                self.peer_rpc.clone(),
+                self.next_hop.clone(),
+            ));
+    }
+
+    pub fn get_next_hop_table(&self) -> DashMap<PeerId, PeerId> {
+        let next_hop = DashMap::new();
+        for item in self.next_hop.iter() {
+            next_hop.insert(item.key().clone(), item.value().clone());
+        }
+        next_hop
+    }
+
+    pub fn get_peer_map(&self) -> Arc<PeerMap> {
+        self.peer_map.clone()
+    }
+}

--- a/easytier-core/src/peers/foreign_network_manager.rs
+++ b/easytier-core/src/peers/foreign_network_manager.rs
@@ -1,0 +1,430 @@
+/*
+foreign_network_manager is used to forward packets of other networks.  currently
+only forward packets of peers that directly connected to this node.
+
+in future, with the help wo peer center we can forward packets of peers that
+connected to any node in the local network.
+*/
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::{
+    sync::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
+    task::JoinSet,
+};
+use tokio_util::bytes::Bytes;
+use uuid::Uuid;
+
+use crate::common::{
+    error::Error,
+    global_ctx::{ArcGlobalCtx, GlobalCtxEvent, NetworkIdentity},
+};
+
+use super::{
+    packet::{self, ArchivedPacketBody},
+    peer_conn::PeerConn,
+    peer_map::PeerMap,
+    peer_rpc::{PeerRpcManager, PeerRpcManagerTransport},
+    PeerId,
+};
+
+struct ForeignNetworkEntry {
+    network: NetworkIdentity,
+    peer_map: Arc<PeerMap>,
+}
+
+impl ForeignNetworkEntry {
+    fn new(
+        network: NetworkIdentity,
+        packet_sender: mpsc::Sender<Bytes>,
+        global_ctx: ArcGlobalCtx,
+    ) -> Self {
+        let peer_map = Arc::new(PeerMap::new(packet_sender, global_ctx));
+        Self { network, peer_map }
+    }
+}
+
+struct ForeignNetworkManagerData {
+    network_peer_maps: DashMap<String, Arc<ForeignNetworkEntry>>,
+    peer_network_map: DashMap<PeerId, String>,
+}
+
+impl ForeignNetworkManagerData {
+    async fn send_msg(&self, msg: Bytes, dst_peer_id: &uuid::Uuid) -> Result<(), Error> {
+        let network_name = self
+            .peer_network_map
+            .get(dst_peer_id)
+            .ok_or_else(|| Error::RouteError("network not found".to_string()))?
+            .clone();
+        let entry = self
+            .network_peer_maps
+            .get(&network_name)
+            .ok_or_else(|| Error::RouteError("no peer in network".to_string()))?
+            .clone();
+        entry.peer_map.send_msg(msg, dst_peer_id).await
+    }
+
+    fn get_peer_network(&self, peer_id: &uuid::Uuid) -> Option<String> {
+        self.peer_network_map.get(peer_id).map(|v| v.clone())
+    }
+
+    fn get_network_entry(&self, network_name: &str) -> Option<Arc<ForeignNetworkEntry>> {
+        self.network_peer_maps.get(network_name).map(|v| v.clone())
+    }
+
+    fn remove_peer(&self, peer_id: &uuid::Uuid) {
+        self.peer_network_map.remove(peer_id);
+        self.network_peer_maps.retain(|_, v| !v.peer_map.is_empty());
+    }
+
+    fn clear_no_conn_peer(&self) {
+        for item in self.network_peer_maps.iter() {
+            let peer_map = item.value().peer_map.clone();
+            tokio::spawn(async move {
+                peer_map.clean_peer_without_conn().await;
+            });
+        }
+    }
+}
+
+struct RpcTransport {
+    my_peer_id: uuid::Uuid,
+    data: Arc<ForeignNetworkManagerData>,
+
+    packet_recv: Mutex<UnboundedReceiver<Bytes>>,
+}
+
+#[async_trait::async_trait]
+impl PeerRpcManagerTransport for RpcTransport {
+    fn my_peer_id(&self) -> Uuid {
+        self.my_peer_id
+    }
+
+    async fn send(&self, msg: Bytes, dst_peer_id: &uuid::Uuid) -> Result<(), Error> {
+        self.data.send_msg(msg, dst_peer_id).await
+    }
+
+    async fn recv(&self) -> Result<Bytes, Error> {
+        if let Some(o) = self.packet_recv.lock().await.recv().await {
+            Ok(o)
+        } else {
+            Err(Error::Unknown)
+        }
+    }
+}
+
+pub const FOREIGN_NETWORK_SERVICE_ID: u32 = 1;
+
+#[tarpc::service]
+pub trait ForeignNetworkService {
+    async fn list_network_peers(network_identy: NetworkIdentity) -> Option<Vec<PeerId>>;
+}
+
+#[tarpc::server]
+impl ForeignNetworkService for Arc<ForeignNetworkManagerData> {
+    async fn list_network_peers(
+        self,
+        _: tarpc::context::Context,
+        network_identy: NetworkIdentity,
+    ) -> Option<Vec<PeerId>> {
+        let entry = self.network_peer_maps.get(&network_identy.network_name)?;
+        Some(entry.peer_map.list_peers().await)
+    }
+}
+
+pub struct ForeignNetworkManager {
+    global_ctx: ArcGlobalCtx,
+    packet_sender_to_mgr: mpsc::Sender<Bytes>,
+
+    packet_sender: mpsc::Sender<Bytes>,
+    packet_recv: Mutex<Option<mpsc::Receiver<Bytes>>>,
+
+    data: Arc<ForeignNetworkManagerData>,
+    rpc_mgr: Arc<PeerRpcManager>,
+    rpc_transport_sender: UnboundedSender<Bytes>,
+
+    tasks: Mutex<JoinSet<()>>,
+}
+
+impl ForeignNetworkManager {
+    pub fn new(global_ctx: ArcGlobalCtx, packet_sender_to_mgr: mpsc::Sender<Bytes>) -> Self {
+        // recv packet from all foreign networks
+        let (packet_sender, packet_recv) = mpsc::channel(1000);
+
+        let data = Arc::new(ForeignNetworkManagerData {
+            network_peer_maps: DashMap::new(),
+            peer_network_map: DashMap::new(),
+        });
+
+        // handle rpc from foreign networks
+        let (rpc_transport_sender, peer_rpc_tspt_recv) = mpsc::unbounded_channel();
+        let rpc_mgr = Arc::new(PeerRpcManager::new(RpcTransport {
+            my_peer_id: global_ctx.get_id(),
+            data: data.clone(),
+            packet_recv: Mutex::new(peer_rpc_tspt_recv),
+        }));
+
+        Self {
+            global_ctx,
+            packet_sender_to_mgr,
+
+            packet_sender,
+            packet_recv: Mutex::new(Some(packet_recv)),
+
+            data,
+            rpc_mgr,
+            rpc_transport_sender,
+
+            tasks: Mutex::new(JoinSet::new()),
+        }
+    }
+
+    pub async fn add_peer_conn(&self, peer_conn: PeerConn) -> Result<(), Error> {
+        tracing::warn!(peer_conn = ?peer_conn.get_conn_info(), network = ?peer_conn.get_network_identity(), "add new peer conn in foreign network manager");
+
+        let entry = self
+            .data
+            .network_peer_maps
+            .entry(peer_conn.get_network_identity().network_name.clone())
+            .or_insert_with(|| {
+                Arc::new(ForeignNetworkEntry::new(
+                    peer_conn.get_network_identity(),
+                    self.packet_sender.clone(),
+                    self.global_ctx.clone(),
+                ))
+            })
+            .clone();
+
+        self.data.peer_network_map.insert(
+            peer_conn.get_peer_id(),
+            peer_conn.get_network_identity().network_name.clone(),
+        );
+
+        if entry.network.network_secret != peer_conn.get_network_identity().network_secret {
+            return Err(anyhow::anyhow!("network secret not match").into());
+        }
+
+        Ok(entry.peer_map.add_new_peer_conn(peer_conn).await)
+    }
+
+    async fn start_global_event_handler(&self) {
+        let data = self.data.clone();
+        let mut s = self.global_ctx.subscribe();
+        self.tasks.lock().await.spawn(async move {
+            while let Ok(e) = s.recv().await {
+                tracing::warn!(?e, "global event");
+                if let GlobalCtxEvent::PeerRemoved(peer_id) = &e {
+                    data.remove_peer(peer_id);
+                } else if let GlobalCtxEvent::PeerConnRemoved(..) = &e {
+                    data.clear_no_conn_peer();
+                }
+            }
+        });
+    }
+
+    async fn start_packet_recv(&self) {
+        let mut recv = self.packet_recv.lock().await.take().unwrap();
+        let sender_to_mgr = self.packet_sender_to_mgr.clone();
+        let my_node_id = self.global_ctx.get_id();
+        let rpc_sender = self.rpc_transport_sender.clone();
+        let data = self.data.clone();
+
+        self.tasks.lock().await.spawn(async move {
+            while let Some(packet_bytes) = recv.recv().await {
+                let packet = packet::Packet::decode(&packet_bytes);
+                let from_peer_uuid = packet.from_peer.to_uuid();
+                let to_peer_uuid = packet.to_peer.as_ref().unwrap().to_uuid();
+                if to_peer_uuid == my_node_id {
+                    if let ArchivedPacketBody::Ctrl(packet::ArchivedCtrlPacketBody::TaRpc(..)) =
+                        &packet.body
+                    {
+                        rpc_sender.send(packet_bytes.clone()).unwrap();
+                        continue;
+                    }
+                    if let Err(e) = sender_to_mgr.send(packet_bytes).await {
+                        tracing::error!("send packet to mgr failed: {:?}", e);
+                    }
+                } else {
+                    let Some(from_network) = data.get_peer_network(&from_peer_uuid) else {
+                        continue;
+                    };
+                    let Some(to_network) = data.get_peer_network(&to_peer_uuid) else {
+                        continue;
+                    };
+                    if from_network != to_network {
+                        continue;
+                    }
+
+                    if let Some(entry) = data.get_network_entry(&from_network) {
+                        let ret = entry.peer_map.send_msg(packet_bytes, &to_peer_uuid).await;
+                        if ret.is_err() {
+                            tracing::error!("forward packet to peer failed: {:?}", ret.err());
+                        }
+                    } else {
+                        tracing::error!("foreign network not found: {}", from_network);
+                    }
+                }
+            }
+        });
+    }
+
+    async fn register_peer_rpc_service(&self) {
+        self.rpc_mgr.run();
+        self.rpc_mgr
+            .run_service(FOREIGN_NETWORK_SERVICE_ID, self.data.clone().serve())
+    }
+
+    pub async fn run(&self) {
+        self.start_global_event_handler().await;
+        self.start_packet_recv().await;
+        self.register_peer_rpc_service().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        common::global_ctx::tests::get_mock_global_ctx_with_network,
+        connector::udp_hole_punch::tests::{
+            create_mock_peer_manager_with_mock_stun, replace_stun_info_collector,
+        },
+        peers::{
+            peer_manager::PeerManager,
+            tests::{connect_peer_manager, wait_route_appear},
+        },
+        rpc::NatType,
+    };
+
+    use super::*;
+
+    async fn create_mock_peer_manager_for_foreign_network(network: &str) -> Arc<PeerManager> {
+        let (s, _r) = tokio::sync::mpsc::channel(1000);
+        let peer_mgr = Arc::new(PeerManager::new(
+            get_mock_global_ctx_with_network(Some(NetworkIdentity {
+                network_name: network.to_string(),
+                network_secret: network.to_string(),
+            })),
+            s,
+        ));
+        replace_stun_info_collector(peer_mgr.clone(), NatType::Unknown);
+        peer_mgr.run().await.unwrap();
+        peer_mgr
+    }
+
+    #[tokio::test]
+    async fn test_foreign_network_manager() {
+        let pm_center = create_mock_peer_manager_with_mock_stun(crate::rpc::NatType::Unknown).await;
+        let pm_center2 =
+            create_mock_peer_manager_with_mock_stun(crate::rpc::NatType::Unknown).await;
+        connect_peer_manager(pm_center.clone(), pm_center2.clone()).await;
+
+        let pma_net1 = create_mock_peer_manager_for_foreign_network("net1").await;
+        let pmb_net1 = create_mock_peer_manager_for_foreign_network("net1").await;
+        connect_peer_manager(pma_net1.clone(), pm_center.clone()).await;
+        connect_peer_manager(pmb_net1.clone(), pm_center.clone()).await;
+
+        let now = std::time::Instant::now();
+        let mut succ = false;
+        while now.elapsed().as_secs() < 10 {
+            let table = pma_net1.get_foreign_network_client().get_next_hop_table();
+            if table.len() >= 1 {
+                succ = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        assert!(succ);
+
+        assert_eq!(
+            vec![pm_center.my_node_id()],
+            pma_net1
+                .get_foreign_network_client()
+                .get_peer_map()
+                .list_peers()
+                .await
+        );
+        assert_eq!(
+            vec![pm_center.my_node_id()],
+            pmb_net1
+                .get_foreign_network_client()
+                .get_peer_map()
+                .list_peers()
+                .await
+        );
+        wait_route_appear(pma_net1.clone(), pmb_net1.my_node_id())
+            .await
+            .unwrap();
+        assert_eq!(1, pma_net1.list_routes().await.len());
+        assert_eq!(1, pmb_net1.list_routes().await.len());
+
+        let pmc_net1 = create_mock_peer_manager_for_foreign_network("net1").await;
+        connect_peer_manager(pmc_net1.clone(), pm_center.clone()).await;
+        wait_route_appear(pma_net1.clone(), pmc_net1.my_node_id())
+            .await
+            .unwrap();
+        wait_route_appear(pmb_net1.clone(), pmc_net1.my_node_id())
+            .await
+            .unwrap();
+        assert_eq!(2, pmc_net1.list_routes().await.len());
+
+        let pma_net2 = create_mock_peer_manager_for_foreign_network("net2").await;
+        let pmb_net2 = create_mock_peer_manager_for_foreign_network("net2").await;
+        connect_peer_manager(pma_net2.clone(), pm_center.clone()).await;
+        connect_peer_manager(pmb_net2.clone(), pm_center.clone()).await;
+        wait_route_appear(pma_net2.clone(), pmb_net2.my_node_id())
+            .await
+            .unwrap();
+        assert_eq!(1, pma_net2.list_routes().await.len());
+        assert_eq!(1, pmb_net2.list_routes().await.len());
+
+        assert_eq!(
+            5,
+            pm_center
+                .get_foreign_network_manager()
+                .data
+                .peer_network_map
+                .len()
+        );
+
+        assert_eq!(
+            2,
+            pm_center
+                .get_foreign_network_manager()
+                .data
+                .network_peer_maps
+                .len()
+        );
+
+        drop(pmb_net2);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        assert_eq!(
+            4,
+            pm_center
+                .get_foreign_network_manager()
+                .data
+                .peer_network_map
+                .len()
+        );
+        drop(pma_net2);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        assert_eq!(
+            3,
+            pm_center
+                .get_foreign_network_manager()
+                .data
+                .peer_network_map
+                .len()
+        );
+        assert_eq!(
+            1,
+            pm_center
+                .get_foreign_network_manager()
+                .data
+                .network_peer_maps
+                .len()
+        );
+    }
+}

--- a/easytier-core/src/peers/mod.rs
+++ b/easytier-core/src/peers/mod.rs
@@ -8,6 +8,9 @@ pub mod peer_rpc;
 pub mod route_trait;
 pub mod rpc_service;
 
+pub mod foreign_network_client;
+pub mod foreign_network_manager;
+
 #[cfg(test)]
 pub mod tests;
 

--- a/easytier-core/src/peers/packet.rs
+++ b/easytier-core/src/peers/packet.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use rkyv::{Archive, Deserialize, Serialize};
 use tokio_util::bytes::Bytes;
 
@@ -47,10 +49,9 @@ impl From<&ArchivedUUID> for UUID {
     }
 }
 
-#[derive(Archive, Deserialize, Serialize, Debug)]
+#[derive(Archive, Deserialize, Serialize)]
 #[archive(compare(PartialEq), check_bytes)]
 // Derives can be passed through to the generated type:
-#[archive_attr(derive(Debug))]
 pub struct NetworkIdentityForPacket(Vec<u8>);
 
 impl From<NetworkIdentity> for NetworkIdentityForPacket {
@@ -68,6 +69,20 @@ impl From<NetworkIdentityForPacket> for NetworkIdentity {
 impl From<&ArchivedNetworkIdentityForPacket> for NetworkIdentity {
     fn from(network: &ArchivedNetworkIdentityForPacket) -> Self {
         NetworkIdentityForPacket(network.0.to_vec()).into()
+    }
+}
+
+impl Debug for NetworkIdentityForPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let network: NetworkIdentity = bincode::deserialize(&self.0).unwrap();
+        write!(f, "{:?}", network)
+    }
+}
+
+impl Debug for ArchivedNetworkIdentityForPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let network: NetworkIdentity = bincode::deserialize(&self.0).unwrap();
+        write!(f, "{:?}", network)
     }
 }
 

--- a/easytier-core/src/peers/peer.rs
+++ b/easytier-core/src/peers/peer.rs
@@ -172,6 +172,7 @@ mod tests {
             "test",
             ConfigFs::new("/tmp/easytier-test"),
             NetNS::new(None),
+            None,
         ));
         let local_peer = Peer::new(uuid::Uuid::new_v4(), local_packet_send, global_ctx.clone());
         let remote_peer = Peer::new(uuid::Uuid::new_v4(), remote_packet_send, global_ctx.clone());

--- a/easytier-core/src/peers/peer.rs
+++ b/easytier-core/src/peers/peer.rs
@@ -146,6 +146,8 @@ impl Peer {
 impl Drop for Peer {
     fn drop(&mut self) {
         self.shutdown_notifier.notify_one();
+        self.global_ctx
+            .issue_event(GlobalCtxEvent::PeerRemoved(self.peer_node_id));
         tracing::info!("peer {} drop", self.peer_node_id);
     }
 }

--- a/easytier-core/src/peers/peer_rpc.rs
+++ b/easytier-core/src/peers/peer_rpc.rs
@@ -222,7 +222,10 @@ impl PeerRpcManager {
         let client_resp_receivers = self.client_resp_receivers.clone();
         tokio::spawn(async move {
             loop {
-                let o = tspt.recv().await.unwrap();
+                let Ok(o) = tspt.recv().await else {
+                    tracing::warn!("peer rpc transport read aborted, exiting");
+                    break;
+                };
                 let packet = Packet::decode(&o);
                 let packet: Packet = packet.deserialize(&mut rkyv::Infallible).unwrap();
                 let info = Self::parse_rpc_packet(&packet).unwrap();


### PR DESCRIPTION
foreign network allow a node serving as one public node. other nodes can
connect to this node to discover peers and exchange route info.