### PR TITLE
🐞 fix: Unable to correctly locate `protoc` in `PATH`

### DIFF
--- a/easytier/build.rs
+++ b/easytier/build.rs
@@ -19,8 +19,8 @@ impl WindowsBuild {
 
         let path = env::var_os("PATH").unwrap_or_default();
         for p in env::split_paths(&path) {
-            let p = p.join("protoc");
-            if p.exists() {
+            let p = p.join("protoc.exe");
+            if p.exists() && p.is_file() {
                 return Some(p);
             }
         }


### PR DESCRIPTION
fix unable to correctly find `protoc` path from `PATH`
just missing the suffix for executable files under Windows
merely converting `protoc` into `protoc.exe`